### PR TITLE
Fix incorrect viewmodel import mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed exception on empty comment #84
+- Fixed incorrect viewmodel import mapping #58
 
 ## [0.0.2] - 2020-11-13
 ### Added

--- a/lib/document-parser.d.ts
+++ b/lib/document-parser.d.ts
@@ -1,4 +1,4 @@
-import { YY } from '../src/parser/document-builder'
+import { YY } from '../src/parser/parser'
 
 export interface GrammarConfig {
 	lex: { rules: (string | string[])[][] }

--- a/spec/src/spec.ts
+++ b/spec/src/spec.ts
@@ -124,8 +124,7 @@ const compilerTests: ([string, (program: lint.Program) => Promise<string | true>
 			diags[0].location?.first_column === 40 && diags[0].location?.last_column === 50 &&
 			diags[0].location?.first_line === 1 && diags[0].location?.last_line === 1) ||
 			'Invalid start and end positions'
-		},
-		'https://github.com/kolint/kolint/issues/58'
+		}
 	],
 	[
 		'Correct start and end positions (binding handler)',

--- a/src/compiler/emit.ts
+++ b/src/compiler/emit.ts
@@ -75,10 +75,10 @@ export function emit(viewPath: string, document: Document): { file: string, sour
 
 	const viewmodelImportModulePath = new SourceNode(
 		// modulePath is a string and can therefore not be multiline
-		document.viewmodelReferences[0].loc.first_line,
-		document.viewmodelReferences[0].loc.last_column - (document.viewmodelReferences[0].modulePath.length + 1),
+		document.viewmodelReferences[0].modulePath.location.first_line,
+		document.viewmodelReferences[0].modulePath.location.first_column - 1,
 		viewPath,
-		`'${document.viewmodelReferences[0].modulePath}'`
+		`'${document.viewmodelReferences[0].modulePath.value}'`
 	)
 
 	root.add(([
@@ -193,7 +193,7 @@ function emitBHImportStatements(refs: BindingHandlerImportNode[], sourcePath: st
 		if (entries.length === 1 && ['*', 'default'].includes(entries[0][0])) {
 
 			const nodes = [
-				`import ${entries[0][0] === '*' ? '* as' : ''}${entries[0][1].isTypeof ? '_' : ''}bindinghandler_${entries[0][1].value} from `, new SourceNode(ref.loc.first_line, ref.loc.first_column, sourcePath, ['\'', ref.modulePath, '\'']), ';\n'
+				`import ${entries[0][0] === '*' ? '* as' : ''}${entries[0][1].isTypeof ? '_' : ''}bindinghandler_${entries[0][1].value} from `, new SourceNode(ref.modulePath.location.first_line, ref.modulePath.location.first_column - 1, sourcePath, ['\'', ref.modulePath.value, '\'']), ';\n'
 			]
 
 			if (entries[0][1].isTypeof)
@@ -208,7 +208,7 @@ function emitBHImportStatements(refs: BindingHandlerImportNode[], sourcePath: st
 						if (name === alias.value) return name
 						else return `${name} as bindinghandler_${alias.value}`
 					else return `${name} as _bindinghandler_${alias.value}`
-				}).join(', ')} } from `, new SourceNode(ref.loc.first_line, ref.loc.first_column, sourcePath, ['\'', ref.modulePath, '\'']), ';\n'
+				}).join(', ')} } from `, new SourceNode(ref.modulePath.location.first_line, ref.modulePath.location.first_column - 1, sourcePath, ['\'', ref.modulePath.value, '\'']), ';\n'
 			]
 
 			if (entries[0][1].isTypeof)

--- a/src/compiler/emit.ts
+++ b/src/compiler/emit.ts
@@ -73,6 +73,14 @@ export function emit(viewPath: string, document: Document): { file: string, sour
 	const contextDeclarationFilePath = path.join(__dirname, '../../lib/context').replace(/\\/g, '/')
 	const { bindingContexts, bindings: bindingStubs } = generateBindingStubs(document.bindings, 'root_context', emit)
 
+	const viewmodelImportModulePath = new SourceNode(
+		// modulePath is a string and can therefore not be multiline
+		document.viewmodelReferences[0].loc.first_line,
+		document.viewmodelReferences[0].loc.last_column - (document.viewmodelReferences[0].modulePath.length + 1),
+		viewPath,
+		`'${document.viewmodelReferences[0].modulePath}'`
+	)
+
 	root.add(([
 
 		newline`/* eslint-disable */`,
@@ -82,23 +90,11 @@ export function emit(viewPath: string, document: Document): { file: string, sour
 		// TODO: multiple import statemnets
 		// TODO: Unique ViewModel names
 		newline(document.viewmodelReferences[0].isTypeof ? [
-			'import _ViewModel from ',
-			new SourceNode(
-				document.viewmodelReferences[0].loc.first_line,
-				document.viewmodelReferences[0].loc.first_column,
-				viewPath,
-				`'${document.viewmodelReferences[0].modulePath}'`
-			),
-			'\ntype ViewModel = typeof _ViewModel'
+			'import _ViewModel from ', viewmodelImportModulePath, '\n',
+			'type ViewModel = typeof _ViewModel\n'
 		] :
 			[
-				'import ViewModel from ',
-				new SourceNode(
-					document.viewmodelReferences[0].loc.first_line,
-					document.viewmodelReferences[0].loc.first_column,
-					viewPath,
-					`'${document.viewmodelReferences[0].modulePath}'`
-				)
+				'import ViewModel from ', viewmodelImportModulePath, '\n'
 			]),
 
 		newline(

--- a/src/parser/bindingDOM.ts
+++ b/src/parser/bindingDOM.ts
@@ -25,13 +25,13 @@ export class Node {
 
 /** Lint Node identifying a viewmodel module to use during type checking */
 export class ViewModelNode extends Node {
-	public constructor(loc: Location, public modulePath: string, public isTypeof: boolean, public name?: string) {
-		super(loc, '', NodeType.Empty)
+	public constructor(location: Location, public modulePath: IdentifierNode<string>, public isTypeof: boolean, public name?: string) {
+		super(location, '', NodeType.Empty)
 	}
 }
 
 export class BindingHandlerImportNode extends Node {
-	public constructor(loc: Location, public modulePath: string, public imports?: Record<string, { isTypeof: boolean, value: string }>) {
+	public constructor(loc: Location, public modulePath: IdentifierNode<string>, public imports?: Record<string, { isTypeof: boolean, value: string }>) {
 		super(loc, '', NodeType.Empty)
 	}
 }
@@ -41,6 +41,10 @@ export class DiagNode extends Node {
 	public constructor(loc: Location, public keys: string[], public enable: boolean) {
 		super(loc, '', NodeType.Empty)
 	}
+}
+
+export class IdentifierNode<T> {
+	public constructor(public value: T, public location: Location) { }
 }
 
 ///

--- a/src/parser/document-builder.ts
+++ b/src/parser/document-builder.ts
@@ -4,20 +4,6 @@ import { Location } from './location'
 import { Diagnostic, diagnostics } from '../diagnostic'
 import { ProgramInternal } from '../program'
 
-/**
- * The shared interface between the jison lexer/parser and the viewParser.
- */
-export interface YY {
-	createViewRefNode(loc: Location, viewReference: string, isTypeof: boolean, name?: string): ViewModelNode
-	createBindingHandlerRefNode(loc: Location, viewReference: string, names: Record<string, { isTypeof: boolean, value: string }>): BindingHandlerImportNode
-	createStartNode(loc: Location, key: string): Node
-	createEndNode(loc: Location, key: string): Node
-	createEmptyNode(loc: Location, key: string): Node
-	createDiagNode(loc: Location, key: string[], enable: boolean): Node
-	createBindingData(loc: Location, data: string): unknown
-	bindingNames: string[] // All attribute names that is matched by knockout for bindings.
-}
-
 // Build binding tree
 export function createDocument(ast: Node[], program: ProgramInternal): Document {
 	const internal = program._internal
@@ -25,8 +11,10 @@ export function createDocument(ast: Node[], program: ProgramInternal): Document 
 	// TODO: Remove root binding
 	const root = new Binding(new BindingName('root', undefined as unknown as Location), new BindingExpression('', undefined as unknown as Location))
 	const bindingStack: Binding[] = [root]
-	const viewmodelStack: ViewModelNode[] = [new ViewModelNode({ first_column: 0, first_line: 0, last_column: 0, last_line: 0, range: [0, 0] }, '', false)]
-	const bindinghandlersStack: BindingHandlerImportNode[] = [new BindingHandlerImportNode({ first_column: 0, first_line: 0, last_column: 0, last_line: 0, range: [0, 0] }, '')]
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const viewmodelStack: ViewModelNode[] = [new ViewModelNode(undefined as any, undefined as any, undefined as any)]
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const bindinghandlersStack: BindingHandlerImportNode[] = [new BindingHandlerImportNode(undefined as any, undefined as any, undefined as any)]
 	const nodeStack: Node[] = []
 	const viewmodels: ViewModelNode[] = []
 	const bindinghandlers: BindingHandlerImportNode[] = []

--- a/src/parser/grammar.jison
+++ b/src/parser/grammar.jison
@@ -185,11 +185,11 @@ attribValue
 
 vmImportRef
   : IMPORT TYPEOF vmImportSpec FROM TEXT
-    { $$ = yy.createViewRefNode(@$, $TEXT, true, $vmImportSpec) }
+    { $$ = yy.createViewRefNode(@$, $TEXT, @TEXT, true, $vmImportSpec) }
   | IMPORT vmImportSpec FROM TEXT
-    { $$ = yy.createViewRefNode(@$, $TEXT, false, $vmImportSpec) }
+    { $$ = yy.createViewRefNode(@$, $TEXT, @TEXT, false, $vmImportSpec) }
   | TEXT
-    { $$ = yy.createViewRefNode(@$, $TEXT, false) }
+    { $$ = yy.createViewRefNode(@$, $TEXT, @TEXT, false) }
   // TODO:
   // Check for `get from` import statements which can be used as a little trick for typescript
   // files not exporting the ViewModel. e.g. "ko-viewmodel: get VM from 'path/to/file'"
@@ -209,7 +209,7 @@ vmImportSpec
 
 bhImportRef
   : IMPORT bhImportSpec FROM TEXT
-    { $$ = yy.createBindingHandlerRefNode(@$, $TEXT, $bhImportSpec) }
+    { $$ = yy.createBindingHandlerRefNode(@$, $TEXT, @TEXT, $bhImportSpec) }
 
     // TODO:
     // Check for `get from` import statements which can be used as a little trick for typescript

--- a/src/parser/parser-compiler.ts
+++ b/src/parser/parser-compiler.ts
@@ -3,7 +3,7 @@
 import { Parser } from 'jison'
 import * as fs from 'fs'
 import * as path from 'path'
-import { YY } from './document-builder'
+import { YY } from './parser'
 import { Node } from './bindingDOM'
 
 const bnf = fs.readFileSync(path.join(__dirname, '../../src/parser/grammar.jison'), 'utf8')

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -77,7 +77,7 @@ export class YY {
 		return new DiagNode(loc, keys, enable)
 	}
 
-	public bindingNames = this._bindingNames ?? ['data-bind']
+	public bindingNames = this._bindingNames.concat(['data-bind'])
 
 	public constructor(private _bindingNames: string[]) { }
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,7 +1,6 @@
 import * as documentParser from '../../lib/document-parser'
 import { Location } from './location'
-import { ViewModelNode, Node, NodeType, BindingData, DiagNode, BindingHandlerImportNode } from './bindingDOM'
-import { YY } from './document-builder'
+import { ViewModelNode, Node, NodeType, BindingData, DiagNode, BindingHandlerImportNode, IdentifierNode } from './bindingDOM'
 import { Program } from '../program'
 
 const selfClosingNodeNames = [
@@ -47,6 +46,43 @@ function transformSelfClosingNodes(ast: Node[]): void {
 }
 
 /**
+ * The shared values between the jison lexer/parser and the viewParser.
+ */
+export class YY {
+	public createViewRefNode = (location: Location, modulePath: string, modulePathLoc: Location, isTypeof: boolean, name?: string): ViewModelNode => {
+		return new ViewModelNode(location, new IdentifierNode(modulePath, modulePathLoc), isTypeof, name)
+	}
+
+	public createBindingHandlerRefNode = (loc: Location, modulePath: string, modulePathLoc: Location, names: Record<string, { isTypeof: boolean, value: string }>): BindingHandlerImportNode => {
+		return new BindingHandlerImportNode(loc, new IdentifierNode(modulePath, modulePathLoc), names)
+	}
+
+	public createStartNode = (loc: Location, key: string): Node => {
+		return new Node(loc, key, NodeType.Start)
+	}
+
+	public createEndNode = (loc: Location, key: string): Node => {
+		return new Node(loc, key, NodeType.End)
+	}
+
+	public createEmptyNode = (loc: Location, key: string): Node => {
+		return new Node(loc, key, NodeType.Empty)
+	}
+
+	public createBindingData = (loc: Location, data: string): BindingData => {
+		return new BindingData(loc, data)
+	}
+
+	public createDiagNode = (loc: Location, keys: string[], enable: boolean): DiagNode => {
+		return new DiagNode(loc, keys, enable)
+	}
+
+	public bindingNames = this._bindingNames ?? ['data-bind']
+
+	public constructor(private _bindingNames: string[]) { }
+}
+
+/**
  * Parse raw HTML or XML knockout view.
  *
  * XML documents are automatically identified if the document has a XML declaration, otherwise the document is identifed as HTML.
@@ -60,18 +96,7 @@ export function parse(document: string, program: Program, bindingNames?: string[
 
 	const nodeParser = new documentParser.Parser<Node[]>()
 
-	const yy: YY = {
-		createViewRefNode: (loc: Location, viewRef: string, isTypeof: boolean, name?: string) => new ViewModelNode(loc, viewRef, isTypeof, name),
-		createBindingHandlerRefNode: (loc: Location, moduleIdentifier: string, names: Record<string, { isTypeof: boolean, value: string }>) => new BindingHandlerImportNode(loc, moduleIdentifier, names),
-		createStartNode: (loc: Location, key: string) => new Node(loc, key, NodeType.Start),
-		createEndNode: (loc: Location, key: string) => new Node(loc, key, NodeType.End),
-		createEmptyNode: (loc: Location, key: string) => new Node(loc, key, NodeType.Empty),
-		createBindingData: (loc: Location, data: string) => new BindingData(loc, data),
-		createDiagNode: (loc: Location, keys: string[], enable: boolean) => new DiagNode(loc, keys, enable),
-		bindingNames: bindingNames ?? ['data-bind']
-	}
-
-	nodeParser.yy = yy
+	nodeParser.yy = new YY(bindingNames ?? [])
 
 	nodeParser.lexer.options.ranges = true
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before continuing, it's short, I promise. -->
<!-- https://github.com/kolint/kolint/blob/master/CONTRIBUTING.md -->

<!-- Briefly describe the pull request and remove the line below -->
Fix the incorrect mapping for view model imports.

**Before**
<pre>&lt;!-- ko-viewmodel: <b>import default from './viewmodel'</b> --&gt;
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</pre>

**Now**
<pre>&lt;!-- ko-viewmodel: import default from <b>'./viewmodel'</b> --&gt;
                                       ^^^^^^^^^^^^^</pre>

Fixes #58
