### PR TITLE
Convert all idents in grammar to identNode

### DIFF
--- a/src/compiler/emit.ts
+++ b/src/compiler/emit.ts
@@ -195,19 +195,20 @@ function emitBHImportStatements(refs: BindingHandlerImportNode[], sourcePath: st
 		const imports = ref.imports.value
 
 		if (imports.length === 1 && ['*', 'default'].includes(imports[0].alias.value)) {
+			// Single import
 
-			// Import is a grammar keyword use import0
-			const import0 = imports[0]
+			const cimport = imports[0]
 
 			const nodes = [
-				`import ${import0.alias.value === '*' ? '* as' : ''}${import0.isTypeof ? '_' : ''}bindinghandler_${import0.name.value} from `, getModulePathNode(), ';\n'
+				`import ${cimport.alias.value === '*' ? '* as' : ''}${cimport.isTypeof ? '_' : ''}bindinghandler_${cimport.name.value} from `, getModulePathNode(), ';\n'
 			]
 
-			if (import0.isTypeof)
-				nodes.push(`type bindinghandler_${import0.name.value} = typeof _bindinghandler_${import0.alias.value};\n`)
+			if (cimport.isTypeof)
+				nodes.push(`type bindinghandler_${cimport.name.value} = typeof _bindinghandler_${cimport.alias.value};\n`)
 
 			return nodes
 		} else {
+			// Mutliple imports
 
 			const importExpressions = imports.map(cimport => {
 				if (cimport.isTypeof)
@@ -233,10 +234,7 @@ function emitBHImportStatements(refs: BindingHandlerImportNode[], sourcePath: st
 	const bindinghandlers = refs.map(ref => {
 		if (!ref.imports) return
 
-		const entries = Object.entries(ref.imports.value)
-
-		return entries.map(entry => entry[1]).map(alias => `'${alias.name.value}': BindingContextTransform<bindinghandler_${alias.name.value}>`)
-
+		return ref.imports.value.map(alias => `'${alias.name.value}': BindingContextTransform<bindinghandler_${alias.name.value}>`)
 	}).filter(is).flat(1)
 
 	const bindinghandlersInterface = `interface BindingContextTransforms extends Overlay<{\n${bindinghandlers.join('\n')}\n}, StandardBindingContextTransforms> { }`

--- a/src/parser/bindingDOM.ts
+++ b/src/parser/bindingDOM.ts
@@ -25,13 +25,19 @@ export class Node {
 
 /** Lint Node identifying a viewmodel module to use during type checking */
 export class ViewModelNode extends Node {
-	public constructor(loc: Location, public modulePath: string, public isTypeof: boolean, public name?: string) {
-		super(loc, '', NodeType.Empty)
+	public constructor(location: Location, public modulePath: IdentifierNode<string>, public isTypeof: boolean, public name?: IdentifierNode<string>) {
+		super(location, '', NodeType.Empty)
 	}
 }
 
+export interface BindingHandlerImport {
+	isTypeof: boolean
+	name: IdentifierNode<string>
+	alias: IdentifierNode<string>
+}
+
 export class BindingHandlerImportNode extends Node {
-	public constructor(loc: Location, public modulePath: string, public imports?: Record<string, { isTypeof: boolean, value: string }>) {
+	public constructor(loc: Location, public modulePath: IdentifierNode<string>, public imports?: IdentifierNode<BindingHandlerImport[]>) {
 		super(loc, '', NodeType.Empty)
 	}
 }
@@ -41,6 +47,10 @@ export class DiagNode extends Node {
 	public constructor(loc: Location, public keys: string[], public enable: boolean) {
 		super(loc, '', NodeType.Empty)
 	}
+}
+
+export class IdentifierNode<T> {
+	public constructor(public value: T, public location: Location) { }
 }
 
 ///

--- a/src/parser/document-builder.ts
+++ b/src/parser/document-builder.ts
@@ -4,20 +4,6 @@ import { Location } from './location'
 import { Diagnostic, diagnostics } from '../diagnostic'
 import { ProgramInternal } from '../program'
 
-/**
- * The shared interface between the jison lexer/parser and the viewParser.
- */
-export interface YY {
-	createViewRefNode(loc: Location, viewReference: string, isTypeof: boolean, name?: string): ViewModelNode
-	createBindingHandlerRefNode(loc: Location, viewReference: string, names: Record<string, { isTypeof: boolean, value: string }>): BindingHandlerImportNode
-	createStartNode(loc: Location, key: string): Node
-	createEndNode(loc: Location, key: string): Node
-	createEmptyNode(loc: Location, key: string): Node
-	createDiagNode(loc: Location, key: string[], enable: boolean): Node
-	createBindingData(loc: Location, data: string): unknown
-	bindingNames: string[] // All attribute names that is matched by knockout for bindings.
-}
-
 // Build binding tree
 export function createDocument(ast: Node[], program: ProgramInternal): Document {
 	const internal = program._internal
@@ -25,8 +11,8 @@ export function createDocument(ast: Node[], program: ProgramInternal): Document 
 	// TODO: Remove root binding
 	const root = new Binding(new BindingName('root', undefined as unknown as Location), new BindingExpression('', undefined as unknown as Location))
 	const bindingStack: Binding[] = [root]
-	const viewmodelStack: ViewModelNode[] = [new ViewModelNode({ first_column: 0, first_line: 0, last_column: 0, last_line: 0, range: [0, 0] }, '', false)]
-	const bindinghandlersStack: BindingHandlerImportNode[] = [new BindingHandlerImportNode({ first_column: 0, first_line: 0, last_column: 0, last_line: 0, range: [0, 0] }, '')]
+	const viewmodelStack: ViewModelNode[] = [new ViewModelNode({ first_column: 0, first_line: 0, last_column: 0, last_line: 0, range: [0, 0] }, undefined as any, false)]
+	const bindinghandlersStack: BindingHandlerImportNode[] = [new BindingHandlerImportNode({ first_column: 0, first_line: 0, last_column: 0, last_line: 0, range: [0, 0] }, undefined as any)]
 	const nodeStack: Node[] = []
 	const viewmodels: ViewModelNode[] = []
 	const bindinghandlers: BindingHandlerImportNode[] = []

--- a/src/parser/grammar.jison
+++ b/src/parser/grammar.jison
@@ -225,9 +225,9 @@ bhImportSpec
   | Ident
     { $$ = { name: yy.ident($0, @0), alias: 'default', isTypeof: false } }
   | TYPEOF STAR AS Ident
-    { $$ = { name: yy.ident($2, @2), alias: '*', isTypeof: true } }
+    { $$ = { name: yy.ident($3, @3), alias: '*', isTypeof: true } }
   | TYPEOF Ident
-    { $$ = { name: yy.ident($0, @0), alias: 'default', isTypeof: true } }
+    { $$ = { name: yy.ident($1, @1), alias: 'default', isTypeof: true } }
   ;
 
 bhImportBlockIdentifiers


### PR DESCRIPTION
Most of all, identifiers in grammar.jison are defined without location. I added the IdentifierNode to the parser's YY and used it in the view model and binding handler refs. It can be added to all nodes in the feature but is not necessary for the time being.

Fixes #113 
Fixes #112
