### PR TITLE
Fix invalid binding handler import grammar

### DIFF
--- a/src/compiler/emit.ts
+++ b/src/compiler/emit.ts
@@ -200,22 +200,17 @@ function emitBHImportStatements(refs: BindingHandlerImportNode[], sourcePath: st
 			const cimport = imports[0]
 
 			const nodes = [
-				`import ${cimport.alias.value === '*' ? '* as' : ''}${cimport.isTypeof ? '_' : ''}bindinghandler_${cimport.name.value} from `, getModulePathNode(), ';\n'
+				`import ${cimport.alias.value === '*' ? '* as ' : ''}${cimport.isTypeof ? '_' : ''}bindinghandler_${cimport.index} from `, getModulePathNode(), ';\n'
 			]
 
 			if (cimport.isTypeof)
-				nodes.push(`type bindinghandler_${cimport.name.value} = typeof _bindinghandler_${cimport.alias.value};\n`)
+				nodes.push(`type bindinghandler_${cimport.index} = typeof _bindinghandler_${cimport.index};\n`)
 
 			return nodes
 		} else {
 			// Mutliple imports
 
-			const importExpressions = imports.map(cimport => {
-				if (cimport.isTypeof)
-					if (cimport.name.value === cimport.alias.value) return cimport.name.value
-					else return `${cimport.name.value} as bindinghandler_${cimport.alias.value}`
-				else return `${cimport.name.value} as _bindinghandler_${cimport.alias.value}`
-			})
+			const importExpressions = imports.map(cimport => `${cimport.name.value} as ${cimport.isTypeof ? '_' : ''}bindinghandler_${cimport.index}`)
 
 			const nodes = [
 				`import { ${importExpressions.join(', ')} } from `, getModulePathNode(), ';\n'
@@ -223,7 +218,7 @@ function emitBHImportStatements(refs: BindingHandlerImportNode[], sourcePath: st
 
 			for (const cimport of imports)
 				if (cimport.isTypeof)
-					nodes.push(`type bindinghandler_${cimport.name.value} = typeof _bindinghandler_${cimport.name.value};\n`)
+					nodes.push(`type bindinghandler_${cimport.name.value} = typeof _bindinghandler_${cimport.index};\n`)
 
 			return nodes
 

--- a/src/parser/bindingDOM.ts
+++ b/src/parser/bindingDOM.ts
@@ -34,6 +34,7 @@ export interface BindingHandlerImport {
 	isTypeof: boolean
 	name: IdentifierNode<string>
 	alias: IdentifierNode<string>
+	index: number
 }
 
 export class BindingHandlerImportNode extends Node {

--- a/src/parser/grammar.jison
+++ b/src/parser/grammar.jison
@@ -221,33 +221,33 @@ bhImportSpec
   // Don't export as ident because we are unable to do it below. Do it in referneces instead.
     { $$ = $bhImportBlockIdentifiers }
   | STAR AS Ident
-    { $$ = [{ name: yy.ident($2, @2), alias: '*', isTypeof: false }] }
+    { $$ = [{ name: yy.ident($3, @3), alias: yy.ident('*'), isTypeof: false }] }
   | Ident
-    { $$ = [{ name: yy.ident($0, @0), alias: 'default', isTypeof: false }] }
+    { $$ = [{ name: yy.ident($1, @1), alias: yy.ident('default'), isTypeof: false }] }
   | TYPEOF STAR AS Ident
-    { $$ = [{ name: yy.ident($3, @3), alias: '*', isTypeof: true }] }
+    { $$ = [{ name: yy.ident($4, @4), alias: yy.ident('*'), isTypeof: true }] }
   | TYPEOF Ident
-    { $$ = [{ name: yy.ident($1, @1), alias: 'default', isTypeof: true }] }
+    { $$ = [{ name: yy.ident($2, @2), alias: yy.ident('default'), isTypeof: true }] }
   ;
 
 bhImportBlockIdentifiers
   : bhImportBlockIdentifiers COMMA bhImportIdentifier
-    { $$ = $bhImportBlockIdentifiers.concat(yy.ident($2, @2)) }
+    { $$ = $bhImportBlockIdentifiers.concat($3) }
   | bhImportBlockIdentifiers COMMA
-    { $$ = [$0] }
+    { $$ = [$1] }
   | bhImportIdentifier
-    { $$ = [yy.ident($0, @0)] }
+    { $$ = [$1] }
   ;
 
 bhImportIdentifier
   : Ident AS Ident
-    { $$ = { name: yy.ident($0, @0), alias: yy.ident($2, @2), isTypeof: false } }
+    { $$ = { name: yy.ident($1, @1), alias: yy.ident($3, @3), isTypeof: false } }
   |	Ident
-    { $$ = { name: yy.ident($0, @0), alias: yy.ident($0, @0), isTypeof: false } }
+    { $$ = { name: yy.ident($1, @1), alias: yy.ident($1, @1), isTypeof: false } }
   | TYPEOF Ident AS Ident
-    { $$ = { name: yy.ident($0, @0), alias: yy.ident($2, @2), isTypeof: true } }
+    { $$ = { name: yy.ident($1, @1), alias: yy.ident($3, @3), isTypeof: true } }
   | TYPEOF Ident
-    { $$ = { name: yy.ident($0, @0), alias: yy.ident($0, @0), isTypeof: true } }
+    { $$ = { name: yy.ident($1, @1), alias: yy.ident($1, @1), isTypeof: true } }
   ;
 
 //#regionend bh_import

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -53,8 +53,10 @@ export class YY {
 		return new ViewModelNode(location, modulePath, isTypeof, name)
 	}
 
-	public createBindingHandlerRefNode = (location: Location, modulePath: IdentifierNode<string>, names: IdentifierNode<BindingHandlerImport[]>): BindingHandlerImportNode => {
-		return new BindingHandlerImportNode(location, modulePath, names)
+	private bhIndex = 0
+	public createBindingHandlerRefNode = (location: Location, modulePath: IdentifierNode<string>, imports: IdentifierNode<BindingHandlerImport[]>): BindingHandlerImportNode => {
+		imports.value.map(cimport => cimport.index = this.bhIndex++)
+		return new BindingHandlerImportNode(location, modulePath, imports)
 	}
 
 	public createStartNode = (loc: Location, key: string): Node => {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before continuing, it's short, I promise. -->
<!-- https://github.com/kolint/kolint/blob/master/CONTRIBUTING.md -->

<!-- Briefly describe the pull request and remove the line below -->
<b>Correct grammar for binding handler imports by:</b>

- [x] in `grammar.jison` in `bhImportSpec`, set all alias to `IdentifierNode`s, which was an error before.
- [x] in `bhImportBlockIdentifiers` in `bhImportBlockIdentifiers`, return `BindingHandlerImport`s instead of `IdentifierNode`s with the `BindingHandlerImport`.
- [x] add index property to `BindingHandlerImport` which can be used to index emitted binding handler imports instead of aliases which may have lead to name collisions when using `* as` or default binding handler imports.

Fixes #128
Fixes #129
