### PR TITLE
Fix grammar.jison rules. Use identifiers where applicable.

### DIFF
--- a/spec/src/spec.ts
+++ b/spec/src/spec.ts
@@ -133,7 +133,7 @@ const compilerTests: ([string, (program: lint.Program) => Promise<string | true>
 			const diags = correctPositionEmitCache = emit.getDiagnostics()
 
 			return (diags.length === 3 &&
-			diags[0].location?.first_column === 40 && diags[0].location?.last_column === 50 &&
+			diags[0].location?.first_column === 39 && diags[0].location?.last_column === 49 &&
 			diags[0].location?.first_line === 1 && diags[0].location?.last_line === 1) ||
 			'Invalid start and end positions'
 		}
@@ -145,7 +145,7 @@ const compilerTests: ([string, (program: lint.Program) => Promise<string | true>
 			const diags = correctPositionEmitCache
 
 			return (diags.length === 3 &&
-			diags[1].location?.first_column === 17 && diags[1].location?.last_column === 23 &&
+			diags[1].location?.first_column === 16 && diags[1].location?.last_column === 22 &&
 			diags[1].location?.first_line === 2 && diags[1].location?.last_line === 2) ||
 			'Invalid start and end positions'
 		}
@@ -157,7 +157,7 @@ const compilerTests: ([string, (program: lint.Program) => Promise<string | true>
 			const diags = correctPositionEmitCache
 
 			return (diags.length === 3 &&
-			diags[2].location?.first_column === 23 && diags[2].location?.last_column === 33 &&
+			diags[2].location?.first_column === 22 && diags[2].location?.last_column === 32 &&
 			diags[2].location?.first_line === 3 && diags[2].location?.last_line === 3) ||
 			'Invalid start and end positions'
 		}

--- a/src/compiler/emit.ts
+++ b/src/compiler/emit.ts
@@ -192,7 +192,7 @@ function emitBHImportStatements(refs: BindingHandlerImportNode[], sourcePath: st
 
 		if (!ref.imports) return
 
-		const imports = ref.imports.value
+		const imports = ref.imports
 
 		if (imports.length === 1 && ['*', 'default'].includes(imports[0].alias.value)) {
 			// Single import
@@ -210,7 +210,7 @@ function emitBHImportStatements(refs: BindingHandlerImportNode[], sourcePath: st
 		} else {
 			// Mutliple imports
 
-			const importExpressions = imports.map(cimport => `${cimport.name.value} as ${cimport.isTypeof ? '_' : ''}bindinghandler_${cimport.index}`)
+			const importExpressions = imports.map(cimport => `${cimport.name.value} as ${cimport.isTypeof ? '_' : ''}${cimport.alias.value}`)
 
 			const nodes = [
 				`import { ${importExpressions.join(', ')} } from `, getModulePathNode(), ';\n'
@@ -229,7 +229,7 @@ function emitBHImportStatements(refs: BindingHandlerImportNode[], sourcePath: st
 	const bindinghandlers = refs.map(ref => {
 		if (!ref.imports) return
 
-		return ref.imports.value.map(alias => `'${alias.name.value}': BindingContextTransform<bindinghandler_${alias.name.value}>`)
+		return ref.imports.map(imp => `'${imp.alias.value}': BindingContextTransform<bindinghandler_${imp.alias.value}>`)
 	}).filter(is).flat(1)
 
 	const bindinghandlersInterface = `interface BindingContextTransforms extends Overlay<{\n${bindinghandlers.join('\n')}\n}, StandardBindingContextTransforms> { }`

--- a/src/parser/bindingDOM.ts
+++ b/src/parser/bindingDOM.ts
@@ -38,7 +38,7 @@ export interface BindingHandlerImport {
 }
 
 export class BindingHandlerImportNode extends Node {
-	public constructor(loc: Location, public modulePath: IdentifierNode<string>, public imports?: IdentifierNode<BindingHandlerImport[]>) {
+	public constructor(loc: Location, public modulePath: IdentifierNode<string>, public imports?: BindingHandlerImport[]) {
 		super(loc, '', NodeType.Empty)
 	}
 }

--- a/src/parser/grammar.jison
+++ b/src/parser/grammar.jison
@@ -20,8 +20,8 @@ XMLPITEXT                         .+?(?=\?>)
 <tag>">"                          this.popState(); return '>'
 <tag>"/"                          return '/'
 <tag>"="                          return 'EQ'
-<tag,bhimport,vmimport>{QTEXT}    yytext = yytext.slice(1,-1); ++yylloc.first_column; --yylloc.last_column; return 'TEXT'
-<tag,bhimport,vmimport>{SQTEXT}   yytext = yytext.slice(1,-1); ++yylloc.first_column; --yylloc.last_column; return 'TEXT'
+<tag,bhimport,vmimport>{QTEXT}    yytext = yytext.slice(1,-1); ++yylloc.range[0]; --yylloc.range[1]; return 'TEXT'
+<tag,bhimport,vmimport>{SQTEXT}   yytext = yytext.slice(1,-1); ++yylloc.range[0]; --yylloc.range[1]; return 'TEXT'
 <tag>{IDENT}                      return yy.bindingNames.includes(yytext) ? 'bindAttr' : 'Ident'
 <bhimport,vmimport>"{"            return 'LBRACE'
 <bhimport,vmimport>"}"            return 'RBRACE'
@@ -185,9 +185,9 @@ attribValue
 
 vmImportRef
   : IMPORT TYPEOF vmImportSpec FROM TEXT
-    { $$ = yy.createViewRefNode(@$, yy.ident($TEXT, @TEXT), true, $vmImportSpec) }
+    { $$ = yy.createViewRefNode(@$, yy.ident($TEXT, @TEXT), true, yy.ident($vmImportSpec, @vmImportSpec)) }
   | IMPORT vmImportSpec FROM TEXT
-    { $$ = yy.createViewRefNode(@$, yy.ident($TEXT, @TEXT), false, $vmImportSpec) }
+    { $$ = yy.createViewRefNode(@$, yy.ident($TEXT, @TEXT), false, yy.ident($vmImportSpec, @vmImportSpec)) }
   | TEXT
     { $$ = yy.createViewRefNode(@$, yy.ident($TEXT, @TEXT), false) }
   // TODO:
@@ -209,7 +209,7 @@ vmImportSpec
 
 bhImportRef
   : IMPORT bhImportSpec FROM TEXT
-    { $$ = yy.createBindingHandlerRefNode(@$, yy.ident($TEXT, @TEXT), yy.ident($bhImportSpec, @bhImportSpec)) }
+    { $$ = yy.createBindingHandlerRefNode(@$, yy.ident($TEXT, @TEXT), $bhImportSpec) }
 
     // TODO:
     // Check for `get from` import statements which can be used as a little trick for typescript
@@ -221,13 +221,13 @@ bhImportSpec
   // Don't export as ident because we are unable to do it below. Do it in referneces instead.
     { $$ = $bhImportBlockIdentifiers }
   | STAR AS Ident
-    { $$ = [{ name: yy.ident($3, @3), alias: yy.ident('*'), isTypeof: false }] }
+    { $$ = [{ name: yy.ident('*', @STAR), alias: yy.ident($3, @3), isTypeof: false }] }
   | Ident
-    { $$ = [{ name: yy.ident($1, @1), alias: yy.ident('default'), isTypeof: false }] }
+    { $$ = [{ name: yy.ident('default', @$), alias: yy.ident($1, @1), isTypeof: false }] }
   | TYPEOF STAR AS Ident
-    { $$ = [{ name: yy.ident($4, @4), alias: yy.ident('*'), isTypeof: true }] }
+    { $$ = [{ name: yy.ident('*', @STAR), alias: yy.ident($4, @4), isTypeof: true }] }
   | TYPEOF Ident
-    { $$ = [{ name: yy.ident($2, @2), alias: yy.ident('default'), isTypeof: true }] }
+    { $$ = [{ name: yy.ident('default', @$), alias: yy.ident($2, @2), isTypeof: true }] }
   ;
 
 bhImportBlockIdentifiers
@@ -245,9 +245,9 @@ bhImportIdentifier
   |	Ident
     { $$ = { name: yy.ident($1, @1), alias: yy.ident($1, @1), isTypeof: false } }
   | TYPEOF Ident AS Ident
-    { $$ = { name: yy.ident($1, @1), alias: yy.ident($3, @3), isTypeof: true } }
+    { $$ = { name: yy.ident($2, @2), alias: yy.ident($4, @4), isTypeof: true } }
   | TYPEOF Ident
-    { $$ = { name: yy.ident($1, @1), alias: yy.ident($1, @1), isTypeof: true } }
+    { $$ = { name: yy.ident($2, @2), alias: yy.ident($2, @2), isTypeof: true } }
   ;
 
 //#regionend bh_import

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -54,8 +54,8 @@ export class YY {
 	}
 
 	private bhIndex = 0
-	public createBindingHandlerRefNode = (location: Location, modulePath: IdentifierNode<string>, imports: IdentifierNode<BindingHandlerImport[]>): BindingHandlerImportNode => {
-		imports.value.map(cimport => cimport.index = this.bhIndex++)
+	public createBindingHandlerRefNode = (location: Location, modulePath: IdentifierNode<string>, imports: BindingHandlerImport[]): BindingHandlerImportNode => {
+		imports.map(cimport => cimport.index = this.bhIndex++)
 		return new BindingHandlerImportNode(location, modulePath, imports)
 	}
 
@@ -106,6 +106,9 @@ export function parse(document: string, reporting: Reporting, bindingNames?: str
 
 	nodeParser.lexer.options.ranges = true
 
+	// Skip the byte order mark (BOM), if present.
+	if (document.charAt(0) === '\uFEFF')
+		document = document.slice(1)
 	const ast = nodeParser.parse(document)
 
 	if (!forceToXML)


### PR DESCRIPTION
Use identifiers consistently in the grammars.
Remove the BOM from input files, since the parser interprets it as a token.

