### PR TITLE
Allow unused vars if identifier starts with an underscore ('_')

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,6 +63,13 @@
 				}
 			}
 		],
+		"@typescript-eslint/no-unused-vars": [
+			"warn",
+			{
+				"varsIgnorePattern": "_.*",
+				"args": "none"
+			}
+		],
 		"semi": [
 			"error",
 			"never"


### PR DESCRIPTION
Sometimes it is necessary to indicate what an actual parameter' name is even though it is unused. Allowing identifiers starting with _, like _hostName, effectively allows for inline documentation of the code.

As a consequence it should not be allowed to use identifiers (as opposed to being unused) starting with an underscore.