### PR TITLE
Change attribute name regex to HTML spec standards

### DIFF
--- a/spec/src/spec.ts
+++ b/spec/src/spec.ts
@@ -30,6 +30,10 @@ const parseTests = {
 		[
 			'Self closed tag with one attribute without / at end',
 			'<img src="./path/to">'
+		],
+		[
+			'Tag with XML namespace (#203)',
+			'<use xlink:href="#slack-tile">'
 		]
 	],
 

--- a/src/parser/grammar.jison
+++ b/src/parser/grammar.jison
@@ -8,6 +8,7 @@ TEXT                              [^\s>]+
 IDENT                             [_a-zA-Z][_\-0-9a-zA-Z]*
 CTEXT                             .+?/(\-\-\>)
 XMLPITEXT                         .+?(?=\?>)
+ATTRNAME                          [^\s"'>/=]*
 
 %%
 
@@ -22,7 +23,7 @@ XMLPITEXT                         .+?(?=\?>)
 <tag>"="                          return 'EQ'
 <tag,bhimport,vmimport>{QTEXT}    yytext = yytext.slice(1,-1); ++yylloc.range[0]; --yylloc.range[1]; return 'TEXT'
 <tag,bhimport,vmimport>{SQTEXT}   yytext = yytext.slice(1,-1); ++yylloc.range[0]; --yylloc.range[1]; return 'TEXT'
-<tag>{IDENT}                      return yy.bindingNames.includes(yytext) ? 'bindAttr' : 'Ident'
+<tag>{ATTRNAME}                   return yy.bindingNames.includes(yytext) ? 'bindAttr' : 'Ident'
 <bhimport,vmimport>"{"            return 'LBRACE'
 <bhimport,vmimport>"}"            return 'RBRACE'
 <bhimport,vmimport>","            return 'COMMA'


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before continuing, it's short, I promise. -->
<!-- https://github.com/kolint/kolint/blob/master/CONTRIBUTING.md -->

<!-- Briefly describe the pull request and remove the line below -->
<b>Change attribute name regex to HTML specification standards<br>https://html.spec.whatwg.org/multipage/syntax.html#attributes-2</b>

Fixes #203 
