### PR TITLE
Fix context inheritance

### DIFF
--- a/examples/contexts/README.md
+++ b/examples/contexts/README.md
@@ -1,0 +1,5 @@
+# Contexts
+Example displaying how context members are inherited.
+
+- Change current working directory to this directory.
+- Run `node ../../bin/kolint.js view.html`

--- a/examples/contexts/tsconfig.json
+++ b/examples/contexts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"module": "CommonJS",
+		"esModuleInterop": true
+	}
+}

--- a/examples/contexts/view.html
+++ b/examples/contexts/view.html
@@ -1,0 +1,12 @@
+<!-- ko-import VM from './viewmodel' -->
+<!-- ko-viewmodel VM -->
+<div>
+	<!-- ko foreach: { data: things, as: 'thing' } -->
+		<span data-bind="text: thing.Label"></span>
+		<span data-bind="text: thing.Age"></span>
+		<!-- ko foreach: { data: thing.Children, as: 'thingy' } -->
+			<span data-bind="text: thingy.Legs"></span>
+			<span data-bind="text: 'Parents age is ' + thing.Age"></span>
+		<!-- /ko -->
+	<!-- /ko -->
+</div>

--- a/examples/contexts/viewmodel.ts
+++ b/examples/contexts/viewmodel.ts
@@ -1,0 +1,34 @@
+import ko from 'knockout'
+
+interface IThing {
+	Label: string;
+	Age: number;
+	Children: IThingy[];
+}
+
+interface IThingy {
+	Legs: number;
+}
+
+class ForEachVM {
+	public readonly things = ko.observableArray<IThing>([
+		{
+			Label: '1st thing',
+			Age: 1,
+			Children: [{ Legs: 4 }, { Legs: 8 }]
+		},
+		{
+			Label: '2nd thing',
+			Age: 2,
+			Children: [{ Legs: 4 }, { Legs: 8 }]
+		},
+		{
+			Label: '3rd thing',
+			Age: 3,
+			Children: [{ Legs: 4 }, { Legs: 8 }]
+		}
+	]);
+}
+
+// We can also export as namespace thanks to ts.config's interop-settings
+export = ForEachVM;

--- a/lib/resources/context.d.ts
+++ b/lib/resources/context.d.ts
@@ -21,7 +21,8 @@ export interface ChildBindingContextImpl<ViewModel, ParentContext extends Bindin
 	$rawData: MaybeReactive<ViewModel>
 }
 
-export type ChildBindingContext<Child, Parent extends BindingContext> = ChildBindingContextImpl<Child, Parent, Parent['$data'], Parent['$root'], [Parent['$data'], ...Parent['$parents']]>
+// Use parent context and override with child context parameters
+export type ChildBindingContext<ViewModel, Parent extends BindingContext> = Parent & ChildBindingContextImpl<ViewModel, Parent, Parent['$data'], Parent['$root'], [...Parent['$parents']]>
 
 export interface BindingHandler<T> {
 	init?: (element: any, valueAccessor: () => T, allBindings?: any, viewModel?: any, bindingContext?: any) => any;


### PR DESCRIPTION
Members from the parent context are not inherited to the child context. This is a regression from earlier cleanups.

An example of the bug is displayed in the first commit, whereas the fix is introduced in the second commit.